### PR TITLE
Chore: Apply useful patches from upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@
 - Dropped support for Django 2.2
 - Removed Django 2.2 testing
 - Added testing for Python 3.10
+- Applied the following parent fork PRs:
+  - https://github.com/Koed00/django-q/pull/603
+  - https://github.com/Koed00/django-q/pull/604
+  - https://github.com/Koed00/django-q/pull/605
+  - https://github.com/Koed00/django-q/pull/423
+  - https://github.com/Koed00/django-q/pull/672
+  - https://github.com/Koed00/django-q/pull/659
 
 Full Changes: https://github.com/Koed00/django-q/compare/master...paperless-ngx:paperless-main
 

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -4,12 +4,10 @@
     - [Cons](#cons)
   - [Simplify Human Hash](#simplify-human-hash)
   - [Event Driven vs Polling](#event-driven-vs-polling)
-  - [Add .editorconfig](#add-editorconfig)
   - [Add .pre-commit-config.yaml](#add-pre-commit-configyaml)
   - [Sub-classing Process](#sub-classing-process)
   - [Better Process Naming](#better-process-naming)
   - [File Organization](#file-organization)
-  - [Useful PRs](#useful-prs)
 
 # Ideas
 
@@ -64,10 +62,6 @@ task in the future, instead of polling continuously?  Set the future timeout in 
 This would be a very large change in the architecture, but if it (or even potions of it) are possible, it would be
 a much better solution than consistently polling and eating up cycles.
 
-## Add .editorconfig
-
-Pretty easy, adding an .editorconfig file will help keep the styling consistent across multiple authors.
-
 ## Add .pre-commit-config.yaml
 
 Along the same idea as above, adding a pre-commit configuration will help enforce styling and formatting,
@@ -93,9 +87,3 @@ an idea of how many times a task has been re-incarnated or recycled)
 The `cluster.py` file contains a lot more than Cluster.  Simplify the file by moving other classes to their own
 files and common functionality to an appropriate file as well.
 
-## Useful PRs
-
-- https://github.com/Koed00/django-q/pull/603
-- https://github.com/Koed00/django-q/pull/604
-- https://github.com/Koed00/django-q/pull/605
-- https://github.com/Koed00/django-q/pull/423

--- a/django_q/admin.py
+++ b/django_q/admin.py
@@ -79,7 +79,7 @@ class ScheduleAdmin(admin.ModelAdmin):
         readonly_fields = ("cron",)
 
     list_filter = ("next_run", "schedule_type", "cluster")
-    search_fields = ("func",)
+    search_fields = ("name", "func",)
     list_display_links = ("id", "name")
 
 

--- a/django_q/admin.py
+++ b/django_q/admin.py
@@ -86,7 +86,7 @@ class ScheduleAdmin(admin.ModelAdmin):
 class QueueAdmin(admin.ModelAdmin):
     """queue admin for ORM broker"""
 
-    list_display = ("id", "key", "task_id", "name", "func", "lock")
+    list_display = ("id", "key", "name",  "group", "func", "lock", "task_id")
 
     def save_model(self, request, obj, form, change):
         obj.save(using=Conf.ORM)

--- a/django_q/admin.py
+++ b/django_q/admin.py
@@ -10,7 +10,7 @@ from django_q.tasks import async_task
 class TaskAdmin(admin.ModelAdmin):
     """model admin for success tasks."""
 
-    list_display = ("name", "func", "started", "stopped", "time_taken", "group")
+    list_display = ("name", "group", "func", "started", "stopped", "time_taken")
 
     def has_add_permission(self, request):
         """Don't allow adds."""
@@ -43,14 +43,14 @@ retry_failed.short_description = _("Resubmit selected tasks to queue")
 class FailAdmin(admin.ModelAdmin):
     """model admin for failed tasks."""
 
-    list_display = ("name", "func", "started", "stopped", "short_result")
+    list_display = ("name", "group", "func", "started", "stopped", "short_result")
 
     def has_add_permission(self, request):
         """Don't allow adds."""
         return False
 
     actions = [retry_failed]
-    search_fields = ("name", "func")
+    search_fields = ("name", "func", "group")
     list_filter = ("group",)
     readonly_fields = []
 

--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -662,7 +662,8 @@ def scheduler(broker: Broker = None):
                         if settings.USE_TZ
                         else next_run.datetime.replace(tzinfo=None)
                     )
-                    s.repeats += -1
+                    if s.repeats > 0:
+                        s.repeats -= 1
                 # send it to the cluster
                 scheduled_broker = broker
                 try:

--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -509,16 +509,18 @@ def save_task(task, broker: Broker):
             func = task["func"]
             # convert func to string
             if inspect.isfunction(func):
-                func = f"{func.__module__}.{func.__name__}"
-            elif inspect.ismethod(func):
-                func = (
+                func_name = f"{func.__module__}.{func.__name__}"
+            elif inspect.ismethod(func) and hasattr(func.__self__, '__name__'):
+                func_name = (
                     f"{func.__self__.__module__}."
                     f"{func.__self__.__name__}.{func.__name__}"
                 )
+            else:
+                func_name = str(func)
             Task.objects.create(
                 id=task["id"],
                 name=task["name"],
-                func=func,
+                func=func_name,
                 hook=task.get("hook"),
                 args=task["args"],
                 kwargs=task["kwargs"],

--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -213,8 +213,9 @@ class Sentinel:
         :param process: the process to reincarnate
         :type process: Process or None
         """
+        # close connections before spawning new process
         if not Conf.SYNC:
-            db.connections.close_all()  # Close any old connections
+            db.connections.close_all()
         if process == self.monitor:
             self.monitor = self.spawn_monitor()
             logger.error(_(f"reincarnated monitor {process.name} after sudden death"))
@@ -238,8 +239,9 @@ class Sentinel:
     def spawn_cluster(self):
         self.pool = []
         Stat(self).save()
+        # close connections before spawning new process
         if not Conf.SYNC:
-            db.connection.close()
+            db.connections.close_all()
         # spawn worker pool
         for __ in range(self.pool_size):
             self.spawn_worker()
@@ -697,7 +699,7 @@ def close_old_django_connections():
         logger.warning(
             "Preserving django database connections because sync=True. Beware "
             "that tasks are now injected in the calling context/transactions "
-            "which may result in unexpected bahaviour."
+            "which may result in unexpected behaviour."
         )
     else:
         db.close_old_connections()

--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -476,12 +476,21 @@ def save_task(task, broker: Broker):
     # SAVE LIMIT > 0: Prune database, SAVE_LIMIT 0: No pruning
     close_old_django_connections()
     try:
-        with db.transaction.atomic():
-            last = Success.objects.select_for_update().last()
-            if task["success"] and 0 < Conf.SAVE_LIMIT <= Success.objects.count():
-                last.delete()
+        if task["success"]:
+            # first apply per group success history limit
+            if "group" in task:
+                with db.transaction.atomic():
+                    qs = Success.objects.filter(group=task["group"])
+                    last = qs.select_for_update().last()
+                    if Conf.SAVE_LIMIT_PER_GROUP <= qs.count():
+                        last.delete()
+            # then apply global success history limit
+            with db.transaction.atomic():
+                last = Success.objects.select_for_update().last()
+                if Conf.SAVE_LIMIT <= Success.objects.count():
+                    last.delete()
         # check if this task has previous results
-        if Task.objects.filter(id=task["id"], name=task["name"]).exists():
+        try:
             existing_task = Task.objects.get(id=task["id"], name=task["name"])
             # only update the result if it hasn't succeeded yet
             if not existing_task.success:
@@ -496,8 +505,7 @@ def save_task(task, broker: Broker):
                 and existing_task.attempt_count >= Conf.MAX_ATTEMPTS
             ):
                 broker.acknowledge(task["ack_id"])
-
-        else:
+        except Task.DoesNotExist:
             func = task["func"]
             # convert func to string
             if inspect.isfunction(func):

--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -86,6 +86,10 @@ class Conf:
     # Failures are always saved
     SAVE_LIMIT = conf.get("save_limit", 250)
 
+    # Maximum number of successful tasks of the same group kept in the database. 0 saves everything. -1 saves none
+    # Failures are always saved
+    SAVE_LIMIT_PER_GROUP = conf.get("save_limit_per_group", 5)
+
     # Guard loop sleep in seconds. Should be between 0 and 60 seconds.
     GUARD_CYCLE = conf.get("guard_cycle", 0.5)
 
@@ -137,8 +141,8 @@ class Conf:
     # Verify if retry and timeout settings are correct
     if not TIMEOUT or (TIMEOUT > RETRY):
         warn(
-            """Retry and timeout are misconfigured. Set retry larger than timeout, 
-        failure to do so will cause the tasks to be retriggered before completion. 
+            """Retry and timeout are misconfigured. Set retry larger than timeout,
+        failure to do so will cause the tasks to be retriggered before completion.
         See https://django-q.readthedocs.io/en/latest/configure.html#retry for details."""
         )
 

--- a/django_q/models.py
+++ b/django_q/models.py
@@ -220,7 +220,10 @@ class Schedule(models.Model):
         return self.func
 
     success.boolean = True
+    success.short_description = _("success")
     last_run.allow_tags = True
+    last_run.short_description = _("last_run")
+
 
     class Meta:
         app_label = "django_q"

--- a/django_q/models.py
+++ b/django_q/models.py
@@ -246,6 +246,9 @@ class OrmQ(models.Model):
     def name(self):
         return self.task()["name"]
 
+    def group(self):
+        return self.task().get("group")
+
     class Meta:
         app_label = "django_q"
         verbose_name = _("Queued task")


### PR DESCRIPTION
This PR applies the following PRs from the upstream project to here:

- https://github.com/Koed00/django-q/pull/603
- https://github.com/Koed00/django-q/pull/604
- https://github.com/Koed00/django-q/pull/605
- https://github.com/Koed00/django-q/pull/423
- https://github.com/Koed00/django-q/pull/659

These bring in a few bug fixes and enhancements, as well as a few QoL changes.  It doesn't fix any issues I know of paperless users encountering, but you never know.

All tests still pass, and the paperless image built to include this branch (at 81f96395609c665654c64b51988b090fc705e534) didn't have any problems.