### PR TITLE
Feature: Worker timeout improvements

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -1,5 +1,6 @@
 # Standard
 import ast
+import enum
 import inspect
 import pydoc
 import signal
@@ -46,6 +47,15 @@ from django_q.queues import Queue
 from django_q.signals import post_execute, pre_execute
 from django_q.signing import BadSignature, SignedPackage
 from django_q.status import Stat, Status
+from django_q.timeouts import JobTimeoutException, UnixSignalDeathPenalty
+
+
+class WorkerStatus(enum.IntEnum):
+    IDLE = 1
+    BUSY = 2
+    RECYCLE = 3
+    TIMEOUT = 4
+    STARTING = 5
 
 
 class Cluster:
@@ -192,7 +202,7 @@ class Sentinel:
         p.daemon = True
         if target == worker:
             p.daemon = Conf.DAEMONIZE_WORKERS
-            p.timer = args[2]
+            p.status = args[2]
             self.pool.append(p)
         p.start()
         return p
@@ -202,7 +212,7 @@ class Sentinel:
 
     def spawn_worker(self):
         self.spawn_process(
-            worker, self.task_queue, self.result_queue, Value("f", -1), self.timeout
+            worker, self.task_queue, self.result_queue, Value('I', WorkerStatus.IDLE.value), self.timeout
         )
 
     def spawn_monitor(self) -> Process:
@@ -225,11 +235,11 @@ class Sentinel:
         else:
             self.pool.remove(process)
             self.spawn_worker()
-            if process.timer.value == 0:
+            if process.status.value == WorkerStatus.TIMEOUT.value:
                 # only need to terminate on timeout, otherwise we risk destabilizing the queues
                 process.terminate()
                 logger.warning(_(f"reincarnated worker {process.name} after timeout"))
-            elif int(process.timer.value) == -2:
+            elif process.status.value == WorkerStatus.RECYCLE.value:
                 logger.info(_(f"recycled worker {process.name}"))
             else:
                 logger.error(_(f"reincarnated worker {process.name} after death"))
@@ -267,14 +277,11 @@ class Sentinel:
         while not self.stop_event.is_set() or not counter:
             # Check Workers
             for p in self.pool:
-                with p.timer.get_lock():
+                with p.status.get_lock():
                     # Are you alive?
-                    if not p.is_alive() or p.timer.value == 0:
+                    if not p.is_alive() or p.status.value in {WorkerStatus.TIMEOUT.value, WorkerStatus.RECYCLE.value}:
                         self.reincarnate(p)
                         continue
-                    # Decrement timer if work is being done
-                    if p.timer.value > 0:
-                        p.timer.value -= cycle
             # Check Monitor
             if not self.monitor.is_alive():
                 self.reincarnate(self.monitor)
@@ -401,24 +408,27 @@ def monitor(result_queue: Queue, broker: Broker = None):
 
 
 def worker(
-    task_queue: Queue, result_queue: Queue, timer: Value, timeout: int = Conf.TIMEOUT
+    task_queue: Queue, result_queue: Queue, status: Value, timeout: int = Conf.TIMEOUT
 ):
     """
     Takes a task from the task queue, tries to execute it and puts the result back in the result queue
     :param timeout: number of seconds wait for a worker to finish.
     :type task_queue: multiprocessing.Queue
     :type result_queue: multiprocessing.Queue
-    :type timer: multiprocessing.Value
+    :type timer: multiprocessing.Value wrapping an unsigned int
     """
     name = current_process().name
     logger.info(_(f"{name} ready for work at {current_process().pid}"))
     task_count = 0
     if timeout is None:
-        timeout = -1
+        # If signal.alarm timeout is 0, no alarm will be scheduled
+        # by signal.alarm
+        timeout = 0
     # Start reading the task queue
     for task in iter(task_queue.get, "STOP"):
         result = None
-        timer.value = -1  # Idle
+        # Got a task package, but have not yet called the work
+        status.value = WorkerStatus.STARTING.value
         task_count += 1
         # Get the function from the task
         logger.info(_(f'{name} processing [{task["name"]}]'))
@@ -427,30 +437,38 @@ def worker(
         if not callable(task["func"]):
             f = pydoc.locate(f)
         close_old_django_connections()
-        timer_value = task.pop("timeout", timeout)
+        timeout = task.pop("timeout", timeout)
         # signal execution
         pre_execute.send(sender="django_q", func=f, task=task)
         # execute the payload
-        timer.value = timer_value  # Busy
+        status.value = WorkerStatus.BUSY.value
         try:
-            res = f(*task["args"], **task["kwargs"])
-            result = (res, True)
+            with UnixSignalDeathPenalty(timeout=timeout):
+                res = f(*task["args"], **task["kwargs"])
+                result = (res, True)
         except Exception as e:
+            if isinstance(e, JobTimeoutException):
+                status.value = WorkerStatus.TIMEOUT.value
             result = (f"{e} : {traceback.format_exc()}", False)
             if error_reporter:
                 error_reporter.report()
             if task.get("sync", False):
                 raise
-        with timer.get_lock():
+        with status.get_lock():
             # Process result
             task["result"] = result[0]
             task["success"] = result[1]
             task["stopped"] = timezone.now()
             result_queue.put(task)
-            timer.value = -1  # Idle
+            # If the worker didn't timeout, go back to idle
+            # Otherwise, break out of the loop
+            if status.value != WorkerStatus.TIMEOUT.value:
+                status.value = WorkerStatus.IDLE.value
+            else:
+                break
             # Recycle
             if task_count == Conf.RECYCLE or rss_check():
-                timer.value = -2  # Recycled
+                status.value = WorkerStatus.RECYCLE.value
                 break
     logger.info(_(f"{name} stopped doing work"))
 

--- a/django_q/tasks.py
+++ b/django_q/tasks.py
@@ -15,6 +15,7 @@ from django_q.models import Schedule, Task
 from django_q.queues import Queue
 from django_q.signals import pre_enqueue
 from django_q.signing import SignedPackage
+from django_q.cluster import WorkerStatus
 
 
 def async_task(func, *args, **kwargs):
@@ -762,7 +763,7 @@ def _sync(pack):
     task = SignedPackage.loads(pack)
     task_queue.put(task)
     task_queue.put("STOP")
-    worker(task_queue, result_queue, Value("f", -1))
+    worker(task_queue, result_queue, Value("I", WorkerStatus.IDLE.value))
     result_queue.put("STOP")
     monitor(result_queue)
     task_queue.close()

--- a/django_q/tasks.py
+++ b/django_q/tasks.py
@@ -15,7 +15,6 @@ from django_q.models import Schedule, Task
 from django_q.queues import Queue
 from django_q.signals import pre_enqueue
 from django_q.signing import SignedPackage
-from django_q.cluster import WorkerStatus
 
 
 def async_task(func, *args, **kwargs):
@@ -757,6 +756,7 @@ class AsyncTask:
 def _sync(pack):
     """Simulate a package travelling through the cluster."""
     from django_q.cluster import monitor, worker
+    from django_q.cluster import WorkerStatus
 
     task_queue = Queue()
     result_queue = Queue()

--- a/django_q/tests/test_scheduler.py
+++ b/django_q/tests/test_scheduler.py
@@ -12,7 +12,7 @@ from django.utils import timezone
 from django.utils.timezone import is_naive
 
 from django_q.brokers import Broker, get_broker
-from django_q.cluster import monitor, pusher, scheduler, worker, localtime
+from django_q.cluster import WorkerStatus, localtime, monitor, pusher, scheduler, worker
 from django_q.conf import Conf
 from django_q.queues import Queue
 from django_q.tasks import Schedule, fetch
@@ -118,7 +118,7 @@ def test_scheduler(broker, monkeypatch):
     task_queue.put("STOP")
     # let a worker handle them
     result_queue = Queue()
-    worker(task_queue, result_queue, Value("b", -1))
+    worker(task_queue, result_queue, Value("I", WorkerStatus.IDLE.value))
     assert result_queue.qsize() == 1
     result_queue.put("STOP")
     # store the results

--- a/django_q/timeouts.py
+++ b/django_q/timeouts.py
@@ -16,6 +16,10 @@ class BaseDeathPenalty:
     """Base class to setup job timeouts."""
 
     def __init__(self, timeout, exception=JobTimeoutException, **kwargs):
+        # If signal.alarm timeout is 0, no alarm will be scheduled
+        # by signal.alarm
+        if timeout is None:
+            timeout = 0
         self._timeout = timeout
         self._exception = exception
 

--- a/django_q/timeouts.py
+++ b/django_q/timeouts.py
@@ -1,0 +1,66 @@
+"""
+Using signal, implements a alarm based callback after a certain amount of time.
+Borrowed from rq: https://github.com/rq/rq/blob/master/rq/timeouts.py
+"""
+import signal
+
+
+class JobTimeoutException(Exception):
+    """Raised when a job takes longer to complete than the allowed maximum
+    timeout value.
+    """
+    pass
+
+
+class BaseDeathPenalty:
+    """Base class to setup job timeouts."""
+
+    def __init__(self, timeout, exception=JobTimeoutException, **kwargs):
+        self._timeout = timeout
+        self._exception = exception
+
+    def __enter__(self):
+        self.setup_death_penalty()
+
+    def __exit__(self, type, value, traceback):
+        # Always cancel immediately, since we're done
+        try:
+            self.cancel_death_penalty()
+        except JobTimeoutException:
+            # Weird case: we're done with the with body, but now the alarm is
+            # fired.  We may safely ignore this situation and consider the
+            # body done.
+            pass
+
+        # __exit__ may return True to supress further exception handling.  We
+        # don't want to suppress any exceptions here, since all errors should
+        # just pass through, BaseTimeoutException being handled normally to the
+        # invoking context.
+        return False
+
+    def setup_death_penalty(self):
+        raise NotImplementedError()
+
+    def cancel_death_penalty(self):
+        raise NotImplementedError()
+
+
+class UnixSignalDeathPenalty(BaseDeathPenalty):
+
+    def handle_death_penalty(self, signum, frame):
+        raise self._exception('Task exceeded maximum timeout value '
+                              '({0} seconds)'.format(self._timeout))
+
+    def setup_death_penalty(self):
+        """Sets up an alarm signal and a signal handler that raises
+        an exception after the timeout amount (expressed in seconds).
+        """
+        signal.signal(signal.SIGALRM, self.handle_death_penalty)
+        signal.alarm(self._timeout)
+
+    def cancel_death_penalty(self):
+        """Removes the death penalty alarm and puts back the system into
+        default signal handling.
+        """
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, signal.SIG_DFL)

--- a/django_q/timeouts.py
+++ b/django_q/timeouts.py
@@ -5,9 +5,10 @@ Borrowed from rq: https://github.com/rq/rq/blob/master/rq/timeouts.py
 import signal
 
 
-class JobTimeoutException(Exception):
+class JobTimeoutException(SystemExit):
     """Raised when a job takes longer to complete than the allowed maximum
-    timeout value.
+    timeout value.  Inherits from SystemExit to prevent user code which catches
+    Exception from not timing out correctly.
     """
     pass
 


### PR DESCRIPTION
This pull request updates how django-q handles its timeout checking to be more effecient, while making the status of a worker more clear.

## Previous Architecture

Previously, the Sentinel guard loop decremented a shared [`Value`](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Value), then terminated the process if the shared value reached 0, as this value indicated a timeout.  Somewhat confusingly, this same timer value was used to reflect worker status, where certain magic numbers indicated the worker was idle (-1) or had ceased working due to reaching a limit for recycling (-2).

## New Architecture

Now, these have been split up and the worker is responsible for setting its own status, while also handling its own timeout.

### Worker Status

Instead of magic numbers, a `IntEnum` is utilized alongside a `Value`.  This is still shared between the Sentinel and the worker, but thanks to the enum, it is more clear what statuses are possible and what they mean.  The value is an `I` or unsigned integer, which is why an `IntEnum` was chosen.

### Worker Timeout

Directly before beginning the task given to it, the worker utilizes [`signal.alarm`](https://docs.python.org/3/library/signal.html#signal.alarm) to schedule an exception to be raised in a given number of seconds.  If the work completes in time, the alarm is canceled.  Otherwise, the task fails and the worker status will be set to indicate a timeout, causing the sentinel to reincarnate the worker.

In the case of no timeout, the alarm is passed a value of 0, which causes no alarm to be scheduled, ending up with infinite time to do the work.

As mentioned in the file, this technique is borrowed from [rq](https://github.com/rq/rq) and seems pretty straightforward. After testing with paperless, this is actually quite useful, as the timeout exception makes it much more clear a task has failed due to timing out.  However, if a task catches `Exception` or `BaseException` and doesn't re-raise something, a worker could keep trying to work forever.  Nothing in a paperless async task should do that though, so these changes are alright for us.